### PR TITLE
Cope with closing a parentheses-wrapped expression within a call

### DIFF
--- a/flake8_multiline_containers.py
+++ b/flake8_multiline_containers.py
@@ -230,7 +230,7 @@ class MultilineContainers:
                 close_times -= 1
                 self.function_depth -= 1
 
-        elif close_times > 0 and open_times == 0:
+        elif close_times > 0 and open_times == 0 and self.last_starts_at:
             index = self._get_closing_index(line, close_character)
 
             if index != self.last_starts_at[-1]:

--- a/tests/dummy/callable/function_call.py
+++ b/tests/dummy/callable/function_call.py
@@ -5,6 +5,14 @@ bizbat ( "Hello",
 bizbat        ( "Hello",
          "World")
 
+# Right
+# Function call containing parens around a long string
+func(
+    (
+        "long string such that we use parens"
+    ),
+)
+
 # Right: Nested function call is ignored
 bizbat(bazbin("""
 """))


### PR DESCRIPTION
This fixes an error where a parenthesized expression nested within a call statement would cause an `IndexError`.

I'm not entirely sure what caused `last_starts_at` to be empty in this case, though this check doesn't appear to have any negative consequences.

Fixes #19.