### PR TITLE
Double speed of analysis for larger codebases

### DIFF
--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -2,10 +2,17 @@ from flake8_multiline_containers import ErrorCodes
 
 
 def test_check_opening_contains_error(linter):
-    linter._check_opening('{', '}', 0, "foo={a\n", ErrorCodes.JS101)
+    linter._check_opening(
+        '{',
+        '}',
+        0,
+        "foo={a\n",
+        [('{', 4)],
+        ErrorCodes.JS101,
+    )
     assert 1 == len(linter.errors)
 
 
 def test_check_opening_no_error(linter):
-    linter._check_opening('{', '}', 0, "foo={\n", ErrorCodes.JS101)
+    linter._check_opening('{', '}', 0, "foo={\n", [('{', 4)], ErrorCodes.JS101)
     assert 0 == len(linter.errors)

--- a/tests/test_line_analysis.py
+++ b/tests/test_line_analysis.py
@@ -1,0 +1,21 @@
+from typing import List, Tuple
+
+from flake8_multiline_containers import analyse_line
+
+import pytest
+
+
+@pytest.mark.parametrize('line,expected', [
+    ("foo", []),
+    ("'[]'", []),
+    ("foo()", [('(', 3), (')', 4)]),
+    ("()", [('(', 0), (')', 1)]),
+    ("({)}", [('(', 0), ('{', 1), (')', 2), ('}', 3)]),
+    ("(('abc', 'def')", [('(', 0), ('(', 1), (')', 14)]),
+    ("('}')", [('(', 0), (')', 4)]),
+    ("('\"', \"'\")", [('(', 0), (')', 9)]),
+    ("(#)", [('(', 0)]),
+])
+def test_line_analysis(line: str, expected: List[Tuple[str, int]]) -> None:
+    actual = analyse_line('{([])}', line)
+    assert actual == expected


### PR DESCRIPTION
This reduces the amount of work done per line significantly, primarily by not searching through it in duplicate for both checks.

While the speedup is hard to notice on small codebases, this offers a speedup of about 2× on a large codebase.

Tested on a 80k line codebase, where the time for this checker drops from ~21s to ~11s.