### PR TITLE
Bugfix: Function call replacement ignores non-matching strings

### DIFF
--- a/flake8_multiline_containers.py
+++ b/flake8_multiline_containers.py
@@ -107,7 +107,7 @@ class MultilineContainers:
         temp_line = line
         for match in re.finditer(r'(\w+\s*\()(.*)(\))', line):
             i = match.group(2)
-            if i is not None:
+            if i not in [None, '']:
                 temp_line = temp_line.replace(i, FUNCTION_STRING)
 
         # Only scan the part of the line after assignment

--- a/tests/dummy/equality.py
+++ b/tests/dummy/equality.py
@@ -1,0 +1,23 @@
+# Equality checks should behave the same way as assignment
+
+# Variable equality check
+bar == {'a': 1, 'b':2}
+
+bar == {
+    'a': 1,
+    'b': 2,
+}
+
+# Function equality check
+foo() == {
+    'a': 1,
+    'b': 2,
+    'c': 3,
+}
+
+
+foo(1, 2, 3) == {
+    'a': 1,
+    'b': 2,
+    'c': 3,
+}

--- a/tests/test_equality.py
+++ b/tests/test_equality.py
@@ -1,0 +1,32 @@
+import os
+
+from flake8.api import legacy as flake8
+
+import pytest
+
+
+@pytest.fixture
+def eq_file_path(dummy_file_path):
+    return f'{dummy_file_path}/equality.py'
+
+
+def test_js101_eq(eq_file_path):
+    style_guide = flake8.get_style_guide(
+        select=['JS101'],
+    )
+
+    p = os.path.abspath(eq_file_path)
+    r = style_guide.check_files([p])
+
+    assert 0 == r.total_errors
+
+
+def test_js102_eq(eq_file_path):
+    style_guide = flake8.get_style_guide(
+        select=['JS102'],
+    )
+
+    p = os.path.abspath(eq_file_path)
+    r = style_guide.check_files([p])
+
+    assert 0 == r.total_errors


### PR DESCRIPTION
Fixes #62