### PR TITLE
Fix: False positive on multiline conditional expressions

### DIFF
--- a/flake8_multiline_containers.py
+++ b/flake8_multiline_containers.py
@@ -165,8 +165,9 @@ class MultilineContainers:
                 [get_left_pad(line)] * open_times,
             )
 
-            # Multiple opening characters
-            if open_times > 1:
+            # Multiple opening characters with no closing
+            # There can only be one hanging opening
+            if (open_times - close_times) > 1:
                 e = _error(line_number + 1, 0, error_code)
                 self.errors.append(e)
 

--- a/tests/dummy/conditional_expression.py
+++ b/tests/dummy/conditional_expression.py
@@ -1,0 +1,18 @@
+# Conditional expression where the third part of the expression is a
+# multiline container
+bar = 0
+
+
+foo = {} if bar == 1 else {
+    "foo": 42,
+}
+
+
+foo = [] if bar == 1 else [
+    42,
+}
+
+
+foo = () if bar == 1 else (
+    42, 42,
+}

--- a/tests/test_conditional_expression.py
+++ b/tests/test_conditional_expression.py
@@ -1,0 +1,35 @@
+import os
+
+from flake8.api import legacy as flake8
+
+import pytest
+
+
+@pytest.fixture
+def conditional_expression_file_path(dummy_file_path):
+    return f'{dummy_file_path}/conditional_expression.py'
+
+
+@pytest.mark.doit1
+def test_js101_conditional_block(conditional_expression_file_path):
+    """Conditional blocks should not trigger JS101."""
+    style_guide = flake8.get_style_guide(
+        select=['JS101'],
+    )
+
+    p = os.path.abspath(conditional_expression_file_path)
+    r = style_guide.check_files([p])
+
+    assert 0 == r.total_errors
+
+
+def test_js102_conditional_block(conditional_expression_file_path):
+    """Conditional blocks should not trigger JS102."""
+    style_guide = flake8.get_style_guide(
+        select=['JS102'],
+    )
+
+    p = os.path.abspath(conditional_expression_file_path)
+    r = style_guide.check_files([p])
+
+    assert 0 == r.total_errors


### PR DESCRIPTION
Catch when: > 1 hanging opening character
Instead of catch when: opening character > 1